### PR TITLE
Fix CLI help menu for mykrobe predict

### DIFF
--- a/src/mykrobe/base.py
+++ b/src/mykrobe/base.py
@@ -103,7 +103,7 @@ genotyping_mixin.add_argument(
 genotyping_mixin.add_argument(
     '--guess_sequence_method',
     action='store_true', 
-    help="Guess if ONT or Illumia based on error rate. If error rate is > 10%, ploidy is set to haploid and a confidence threshold is used ")
+    help="Guess if ONT or Illumia based on error rate. If error rate is > 10%%, ploidy is set to haploid and a confidence threshold is used ")
 genotyping_mixin.add_argument(
     '--ignore_minor_calls',
     action='store_true',
@@ -151,7 +151,7 @@ genotyping_mixin.add_argument(
     default=1, type=int)
 genotyping_mixin.add_argument(
     "--min_proportion_expected_depth",
-    help="minimum depth required on the sum of both alleles. Default 0.3 (30%)",
+    help="minimum depth required on the sum of both alleles. Default 0.3 (30%%)",
     default=0.3, type=float)
 genotyping_mixin.add_argument(
     "--min_gene_percent_covg_threshold",

--- a/src/mykrobe/parser.py
+++ b/src/mykrobe/parser.py
@@ -91,7 +91,7 @@ parser_amr.add_argument(
     '--panel',
     metavar='panel',
     type=str,
-    help='variant panel (default:walker-2015). custom requires custom_probe_set_path and custom_variant_to_resistance_json to be set',
+    help='variant panel (default:201901). custom requires custom_probe_set_path and custom_variant_to_resistance_json to be set',
     choices=['bradley-2015', 'walker-2015', '201901', 'atlas', 'custom'],
     default='201901')
 parser_amr.add_argument(

--- a/src/mykrobe/parser.py
+++ b/src/mykrobe/parser.py
@@ -57,7 +57,7 @@ parser = argparse.ArgumentParser(
     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 parser.add_argument("--version", help="mykrobe-atlas version",
                     action="version",
-                    version="%(prog)s " + str(__version__))
+                    version="%%(prog)s " + str(__version__))
 subparsers = parser.add_subparsers(
     title='[sub-commands]',
     dest='command',
@@ -116,7 +116,7 @@ parser_amr.add_argument(
     '--conf_percent_cutoff',
     metavar='conf_percent_cutoff',
     type=float,
-    help='Number between 0 and 100. Determines --min_variant_conf, by simulating variants and choosing the cutoff that would keep x% of the variants. Default is 90 if --ont, otherwise --min_variant_conf is used as the cutoff',
+    help='Number between 0 and 100. Determines --min_variant_conf, by simulating variants and choosing the cutoff that would keep x%% of the variants. Default is 90 if --ont, otherwise --min_variant_conf is used as the cutoff',
     default=-1)
 parser_amr.add_argument(
     '--format',


### PR DESCRIPTION
Literal percent (%) symbols need to be escaped with another percent symbol. This was causing problems when trying to call the `--help` argument of `mykrobe predict`.

Fixes #39 