### PR TITLE
Fix another instance of mongoengine TypeError

### DIFF
--- a/src/mykrobe/metagenomics/phylo.py
+++ b/src/mykrobe/metagenomics/phylo.py
@@ -62,7 +62,7 @@ class SpeciesPredictor(object):
     def run(self):
         self._load_taxon_thresholds()
         self._aggregate_all()
-        return MykrobePredictorPhylogeneticsResult(self.out_json["phylogenetics"])
+        return MykrobePredictorPhylogeneticsResult(phylogenetics=self.out_json["phylogenetics"])
 
     def _add_unknown_where_empty(self, covgs):
         if not covgs:


### PR DESCRIPTION
This hopefully fixes all the TypeErrors from issue #77 . It fixes a second instance of that error (first one fixed in PR #80). 

Cause was that the API of mongoengine changed somewhere between versions 0.18.2 and 0.19.1 (the latest at the time of writing). This fix works for both versions of mongoengine.