### PR TITLE
Make species-panel combination parsing more robust

### DIFF
--- a/src/mykrobe/cmds/amr.py
+++ b/src/mykrobe/cmds/amr.py
@@ -195,7 +195,6 @@ class MykrobePredictorResult(object):
 class Species(Enum):
     TB = "tb"
     STAPH = "staph"
-    GN = "gn"
 
 
 class TbPanel(Enum):
@@ -211,11 +210,7 @@ class StaphPanel(Enum):
     CUSTOM = "custom"
 
 
-class GnPanel(Enum):
-    DEFAULT = "default"
-
-
-PanelName = Union[StaphPanel, TbPanel, GnPanel]
+PanelName = Union[StaphPanel, TbPanel]
 
 
 class Panel(NamedTuple):
@@ -228,8 +223,6 @@ class Panel(NamedTuple):
             panel_name = StaphPanel(name)
         elif species is Species.TB:
             panel_name = TbPanel(name)
-        elif species is Species.GN:
-            panel_name = GnPanel(name)
         else:
             raise NameError(f"{species} is not a known species.")
 
@@ -248,14 +241,6 @@ PANELS = {
             "data/panels/staph-amr-bradley_2015-feb-17-2017.fasta.gz",
         ],
         StaphPanel.CUSTOM: ["data/panels/staph-species-160227.fasta.gz"],
-    },
-    Species.GN: {
-        GnPanel.DEFAULT: [
-            "data/panels/gn-amr-genes",
-            "data/panels/Escherichia_coli",
-            "data/panels/Klebsiella_pneumoniae",
-            "data/panels/gn-amr-genes-extended",
-        ]
     },
     Species.TB: {
         TbPanel.ATLAS: [
@@ -348,18 +333,12 @@ def run(parser, args):
             )
         variant_to_resistance_json_fp = args.custom_variant_to_resistance_json
 
-    # todo: the following two lines are flagged for deletion. Based on the current CLI
-    # implementation, we cannot get to here without there being a species
-    # if not species:
-    #     panels = TB_PANELS + GN_PANELS + STAPH_PANELS
     if species is Species.STAPH:
         Predictor = StaphPredictor
         args.kmer = 15  # Forced
     elif species is Species.TB:
         hierarchy_json_file = "data/phylo/mtbc_hierarchy.json"
         Predictor = TBPredictor
-    elif species is Species.GN:
-        raise NotImplementedError("Predictor not implement for gram negatives.")
     else:
         raise ValueError(f"Unrecognised species {species}")
 

--- a/src/mykrobe/cmds/amr.py
+++ b/src/mykrobe/cmds/amr.py
@@ -1,9 +1,9 @@
 from __future__ import print_function
+
 import logging
 
 logger = logging.getLogger(__name__)
 
-from pprint import pprint
 import json
 
 import numpy as np
@@ -11,7 +11,6 @@ import os
 import random
 import time
 from mykrobe.mformat import json_to_csv
-from mykrobe.utils import check_args
 from mykrobe.typing import CoverageParser
 from mykrobe.typing import Genotyper
 from mykrobe.typing.models.base import ProbeCoverage
@@ -21,14 +20,8 @@ from mykrobe.predict import TBPredictor
 from mykrobe.predict import StaphPredictor
 from mykrobe.predict import MykrobePredictorSusceptibilityResult
 from mykrobe.metagenomics import AMRSpeciesPredictor
-from mykrobe.metagenomics import MykrobePredictorPhylogeneticsResult
 from mykrobe.version import __version__ as predictor_version
 from mykrobe.version import __version__ as atlas_version
-
-from mongoengine import EmbeddedDocumentField
-from mongoengine import IntField
-from mongoengine import DictField
-from mongoengine import StringField
 
 STAPH_PANELS = [
     "data/panels/staph-species-160227.fasta.gz",

--- a/src/mykrobe/cmds/amr.py
+++ b/src/mykrobe/cmds/amr.py
@@ -210,10 +210,13 @@ class StaphPanel(Enum):
     DEFAULT = "default"
     CUSTOM = "custom"
 
+
 class GnPanel(Enum):
     DEFAULT = "default"
 
+
 PanelName = Union[StaphPanel, TbPanel, GnPanel]
+
 
 class Panel(NamedTuple):
     paths: List[str]
@@ -244,9 +247,8 @@ PANELS = {
             "data/panels/staph-species-160227.fasta.gz",
             "data/panels/staph-amr-bradley_2015-feb-17-2017.fasta.gz",
         ],
-        StaphPanel.CUSTOM: ["data/panels/staph-species-160227.fasta.gz"]
-    }
-    ,
+        StaphPanel.CUSTOM: ["data/panels/staph-species-160227.fasta.gz"],
+    },
     Species.GN: {
         GnPanel.DEFAULT: [
             "data/panels/gn-amr-genes",
@@ -254,8 +256,7 @@ PANELS = {
             "data/panels/Klebsiella_pneumoniae",
             "data/panels/gn-amr-genes-extended",
         ]
-    }
-    ,
+    },
     Species.TB: {
         TbPanel.ATLAS: [
             "data/panels/tb-species-170421.fasta.gz",
@@ -274,8 +275,8 @@ PANELS = {
             "data/panels/tb-species-170421.fasta.gz",
             "data/panels/tb-hunt-probe-set-jan-03-2019.fasta.gz",
         ],
-        TbPanel.CUSTOM: ["data/panels/tb-species-170421.fasta.gz"]
-    }
+        TbPanel.CUSTOM: ["data/panels/tb-species-170421.fasta.gz"],
+    },
 }
 
 
@@ -340,8 +341,10 @@ def run(parser, args):
 
         if not os.path.exists(args.custom_variant_to_resistance_json):
             raise FileNotFoundError(
-                ("Custom variant to resistance json "
-                 f"{args.custom_variant_to_resistance_json} does not exist!")
+                (
+                    "Custom variant to resistance json "
+                    f"{args.custom_variant_to_resistance_json} does not exist!"
+                )
             )
         variant_to_resistance_json_fp = args.custom_variant_to_resistance_json
 
@@ -443,9 +446,10 @@ def run(parser, args):
             ploidy=args.ploidy,
         )
         gt.run()
-        kmer_count_error_rate, incorrect_kmer_to_pc_cov = (
-            gt.estimate_kmer_count_error_rate_and_incorrect_kmer_to_percent_cov()
-        )
+        (
+            kmer_count_error_rate,
+            incorrect_kmer_to_pc_cov,
+        ) = gt.estimate_kmer_count_error_rate_and_incorrect_kmer_to_percent_cov()
         logger.info(
             "Estimated error rate for kmer count model: "
             + str(round(100 * kmer_count_error_rate, 2))
@@ -555,8 +559,10 @@ def run(parser, args):
 
     if len(outputs) == 0:
         raise ValueError(
-            (f"Output format must be one of: csv,json,json_and_csv. Got "
-             f"'{args.output_format}'")
+            (
+                f"Output format must be one of: csv,json,json_and_csv. Got "
+                f"'{args.output_format}'"
+            )
         )
 
     for output_type, output in outputs.items():

--- a/tests/predict_tests/test_amr.py
+++ b/tests/predict_tests/test_amr.py
@@ -1,21 +1,23 @@
 import sys
+import pytest
+
 sys.path.append(".")
 from unittest import TestCase
 
 from mykrobe.variants.schema.models import VariantCall
 from mykrobe.variants.schema.models import Variant
+from mykrobe.cmds.amr import Panel, Species, TbPanel, StaphPanel, GnPanel, PANELS
 
 from mykrobe.predict import TBPredictor
 
 
 class AMRPredictTest(TestCase):
-
     def setUp(self):
-        self.variant_snp = Variant.create(start=0, end=1, reference_bases="A",
-                                          alternate_bases=["T"])
+        self.variant_snp = Variant.create(
+            start=0, end=1, reference_bases="A", alternate_bases=["T"]
+        )
 
-        self.predictor = TBPredictor(variant_calls={},
-                                     called_genes={})
+        self.predictor = TBPredictor(variant_calls={}, called_genes={})
 
     def teardown(self):
         pass
@@ -23,25 +25,106 @@ class AMRPredictTest(TestCase):
     def test_wt_vars(self):
         call = {
             "variant": None,
-            "genotype": [
-                0,
-                1],
-            "genotype_likelihoods": [
-                0.1,
-                0.9,
-                0.12],
+            "genotype": [0, 1],
+            "genotype_likelihoods": [0.1, 0.9, 0.12],
             "info": {
                 "contamination_depths": [],
                 "coverage": {
                     "alternate": {
                         "percent_coverage": 100.0,
                         "median_depth": 15,
-                        "min_depth": 2},
+                        "min_depth": 2,
+                    },
                     "reference": {
                         "percent_coverage": 100.0,
                         "median_depth": 139,
-                        "min_depth": 128}},
-                "expected_depths": [152]}}
+                        "min_depth": 128,
+                    },
+                },
+                "expected_depths": [152],
+            },
+        }
 
-        assert self.predictor._coverage_greater_than_threshold(call, [
-                                                               ""]) == False
+        assert self.predictor._coverage_greater_than_threshold(call, [""]) == False
+
+
+class TestPanel:
+    def test_fromSpeciesAndName_invalidSpecies_raisesError(self):
+        species = "foo"
+        name = "bar"
+        with pytest.raises(NameError):
+            Panel.from_species_and_name(species, name)
+
+    def test_fromSpeciesAndName_tbWithInvalidPanel_raisesError(self):
+        species = Species.TB
+        name = "bar"
+        with pytest.raises(ValueError):
+            Panel.from_species_and_name(species, name)
+
+    def test_fromSpeciesAndName_staphWithInvalidPanel_raisesError(self):
+        species = Species.STAPH
+        name = "bar"
+        with pytest.raises(ValueError):
+            Panel.from_species_and_name(species, name)
+
+    def test_fromSpeciesAndName_gnWithInvalidPanel_raisesError(self):
+        species = Species.GN
+        name = "bar"
+        with pytest.raises(ValueError):
+            Panel.from_species_and_name(species, name)
+
+    def test_fromSpeciesAndName_staphWithCustomPanel_returnsCustom(self):
+        species = Species.STAPH
+        name = "custom"
+        panel = Panel.from_species_and_name(species, name)
+
+        actual = panel.name
+        expected = StaphPanel.CUSTOM
+
+        assert actual == expected
+
+    def test_fromSpeciesAndName_TbWithValidPanel_returnsPanel(self):
+        species = Species.TB
+        name = "201901"
+        panel = Panel.from_species_and_name(species, name)
+
+        actual = panel.name
+        expected = TbPanel.NEJM_WALKER
+
+        assert actual == expected
+
+    def test_fromSpeciesAndName_GnWithValidPanel_returnsPanel(self):
+        species = Species.GN
+        name = "default"
+        panel = Panel.from_species_and_name(species, name)
+
+        actual = panel.name
+        expected = GnPanel.DEFAULT
+
+        assert actual == expected
+
+    def test_add_multiple_paths(self):
+        species = Species.TB
+        name = "201901"
+        panel = Panel.from_species_and_name(species, name)
+        additions = ["foo", "bar"]
+        panel.add_path(*additions)
+
+        actual = panel.paths
+        expected = PANELS[species][panel.name]
+        expected.extend(additions)
+
+        assert actual == expected
+
+    def test_add_single_path(self):
+        species = Species.TB
+        name = "201901"
+        panel = Panel.from_species_and_name(species, name)
+        additions = "foo"
+        panel.add_path(*additions)
+
+        actual = panel.paths
+        expected = PANELS[species][panel.name]
+        expected.append(additions)
+
+        assert actual == expected

--- a/tests/predict_tests/test_amr.py
+++ b/tests/predict_tests/test_amr.py
@@ -1,14 +1,9 @@
-import sys
-import pytest
-
-sys.path.append(".")
 from unittest import TestCase
 
-from mykrobe.variants.schema.models import VariantCall
-from mykrobe.variants.schema.models import Variant
-from mykrobe.cmds.amr import Panel, Species, TbPanel, StaphPanel, GnPanel, PANELS
-
+import pytest
+from mykrobe.cmds.amr import Panel, Species, TbPanel, StaphPanel, PANELS
 from mykrobe.predict import TBPredictor
+from mykrobe.variants.schema.models import Variant
 
 
 class AMRPredictTest(TestCase):
@@ -45,7 +40,7 @@ class AMRPredictTest(TestCase):
             },
         }
 
-        assert self.predictor._coverage_greater_than_threshold(call, [""]) == False
+        assert self.predictor._coverage_greater_than_threshold(call, [""]) is False
 
 
 class TestPanel:
@@ -67,12 +62,6 @@ class TestPanel:
         with pytest.raises(ValueError):
             Panel.from_species_and_name(species, name)
 
-    def test_fromSpeciesAndName_gnWithInvalidPanel_raisesError(self):
-        species = Species.GN
-        name = "bar"
-        with pytest.raises(ValueError):
-            Panel.from_species_and_name(species, name)
-
     def test_fromSpeciesAndName_staphWithCustomPanel_returnsCustom(self):
         species = Species.STAPH
         name = "custom"
@@ -90,16 +79,6 @@ class TestPanel:
 
         actual = panel.name
         expected = TbPanel.NEJM_WALKER
-
-        assert actual == expected
-
-    def test_fromSpeciesAndName_GnWithValidPanel_returnsPanel(self):
-        species = Species.GN
-        name = "default"
-        panel = Panel.from_species_and_name(species, name)
-
-        actual = panel.name
-        expected = GnPanel.DEFAULT
 
         assert actual == expected
 


### PR DESCRIPTION
The current species-panel selection/parsing is incorrect. We basically don't handle non-TB.

Fixes #88 

*Note: I have done `black` formatting in the last commit, so see https://github.com/Mykrobe-tools/mykrobe/commit/9dc0ea864bd512017dcadc6f4be6df0c59f27c31 for the real changes*