### PR TITLE
Make background variants db path configurable

### DIFF
--- a/src/mykrobe/cmds/dump.py
+++ b/src/mykrobe/cmds/dump.py
@@ -32,7 +32,7 @@ def get_non_singelton_variants(db_name):
 
 def run(parser, args):
     db_name = '%s-%s' % (DB_PREFIX, args.db_name)
-    DB = connect(db_name)
+    DB = connect(db_name, host=args.db_uri)
     if args.verbose:
         logger.setLevel(level=logging.DEBUG)
     else:

--- a/src/mykrobe/cmds/makeprobes.py
+++ b/src/mykrobe/cmds/makeprobes.py
@@ -39,7 +39,7 @@ def run(parser, args):
         logger.info("Not connecting to database, because --no-backgrounds option used")
         DB = None
     else:
-        DB = connect("%s-%s" % (DB_PREFIX, args.db_name))
+        DB = connect("%s-%s" % (DB_PREFIX, args.db_name), host=args.db_uri)
 
     if DB is not None:
         try:

--- a/src/mykrobe/cmds/variants/add.py
+++ b/src/mykrobe/cmds/variants/add.py
@@ -51,7 +51,7 @@ def run(parser, args):
         logger.setLevel(logging.INFO)
     DBNAME = '%s-%s' % (DB_PREFIX, args.db_name)
     db = client[DBNAME]
-    connect(DBNAME)
+    connect(DBNAME, host=args.db_uri)
     logger.debug("Using DB %s" % DBNAME)
     reference_set_name = ".".join(os.path.basename(
         args.reference_set).split(".")[:-1])

--- a/src/mykrobe/parser.py
+++ b/src/mykrobe/parser.py
@@ -114,6 +114,9 @@ db_parser_mixin = argparse.ArgumentParser(add_help=False)
 db_parser_mixin.add_argument(
     "--db_name", metavar="db_name", type=str, help="db_name", default="default"
 )
+db_parser_mixin.add_argument(
+    "--db_uri", metavar="db_uri", type=str, help="e.g.: mongodb://admin:qwerty@localhost/db_name", default=None
+)
 
 # ##########
 # # AMR predict

--- a/src/mykrobe/probes/probe_generation.py
+++ b/src/mykrobe/probes/probe_generation.py
@@ -2,7 +2,6 @@ from __future__ import print_function
 import csv
 import sys
 from collections import Counter
-from mongoengine import connect
 from pymongo.errors import ServerSelectionTimeoutError
 from mykrobe.variants.schema.models import Variant
 from mykrobe.utils import split_var_name


### PR DESCRIPTION
Previously, the Mykrobe `make_probes` command will connect to the default background variants db at `localhost:27017`. This pull request adds an argument (`--db_uri`) to allow user specified db path.