### PR TITLE
make default temp directory more "temporary" and fix memory and threads CLI params being passed on to mccortex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,4 @@ data
 test-probes.txt
 z.test.pncA_T2ATAC.txt
 
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
+this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- If `--tmp` is not specified now, it is set to [`tempfile.mkdtemp()`][mkdtemp]. By
+  default, this is a directory that is created within the `$TMPDIR`. The reason for this
+  is that currently, when mykrobe cleans up temporary files, it doesn't remove the
+  temporary directory ([#113][113]). I wasn't really comfortable with removing the
+  temporary directory in case the user had set it to something like the current
+  directory. At least with this default now the temporary directory won't clog up the
+  current directory after mykrobe is finished and the OS should clean it up
+  periodically.
+
+[113]: https://github.com/Mykrobe-tools/mykrobe/issues/113
+[Unreleased]: https://github.com/Mykrobe-tools/mykrobe/compare/v0.9.0...HEAD
+[mkdtemp]: https://docs.python.org/3.6/library/tempfile.html#tempfile.mkdtemp
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,10 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   directory. At least with this default now the temporary directory won't clog up the
   current directory after mykrobe is finished and the OS should clean it up
   periodically.
+- Ensure `--memory` and `--threads` are passed on to mccortex [[#114][114]].
 
 [113]: https://github.com/Mykrobe-tools/mykrobe/issues/113
+[114]: https://github.com/Mykrobe-tools/mykrobe/issues/114
 [Unreleased]: https://github.com/Mykrobe-tools/mykrobe/compare/v0.9.0...HEAD
 [mkdtemp]: https://docs.python.org/3.6/library/tempfile.html#tempfile.mkdtemp
 

--- a/src/mykrobe/base.py
+++ b/src/mykrobe/base.py
@@ -16,12 +16,12 @@ sequence_or_graph_parser_mixin.add_argument(
     '--kmer',
     metavar='kmer',
     type=int,
-    help='kmer length (default:21)',
+    help='kmer length (default: %(default)d)',
     default=DEFAULT_KMER_SIZE)
 sequence_or_graph_parser_mixin.add_argument(
     '--tmp',
-    help='tmp directory (default: tmp/)',
-    default="tmp/")
+    help='Directory to write temporary files to',
+    default=None)
 sequence_or_graph_parser_mixin.add_argument(
     '--keep_tmp',
     help="Dont remove tmp files",

--- a/src/mykrobe/cmds/amr.py
+++ b/src/mykrobe/cmds/amr.py
@@ -275,10 +275,11 @@ def run(parser, args):
         seq=args.seq,
         kmer=ref_data["kmer"],
         force=args.force,
-        threads=1,
+        threads=args.threads,
         verbose=False,
         tmp_dir=args.tmp,
         skeleton_dir=args.skeleton_dir,
+        memory=args.memory
     )
     cp.run()
     logger.debug("CoverageParser complete")

--- a/src/mykrobe/cmds/amr.py
+++ b/src/mykrobe/cmds/amr.py
@@ -1,25 +1,22 @@
 from __future__ import print_function
 
 import logging
+import tempfile
 
 logger = logging.getLogger(__name__)
 
 import json
 
 import numpy as np
-import os
 import random
 import sys
 import time
-from enum import Enum
 from mykrobe.mformat import json_to_csv
 from mykrobe.typing import CoverageParser
 from mykrobe.typing import Genotyper
 from mykrobe.typing.models.base import ProbeCoverage
 from mykrobe.typing.models.variant import VariantProbeCoverage
 from mykrobe.typing.typer.variant import VariantTyper
-from mykrobe.predict import TBPredictor
-from mykrobe.predict import StaphPredictor
 from mykrobe.predict import BasePredictor
 from mykrobe.predict import MykrobePredictorSusceptibilityResult
 from mykrobe.metagenomics import AMRSpeciesPredictor
@@ -267,6 +264,9 @@ def run(parser, args):
     logger.info(
         f"Running mykrobe predict using species {args.species}, and panel version {ref_data['version']}"
     )
+
+    if args.tmp is None:
+        args.tmp = tempfile.mkdtemp() + "/"
 
     # Run Cortex
     cp = CoverageParser(


### PR DESCRIPTION
This will close #113 and close #114

### Changed

- If `--tmp` is not specified now, it is set to [`tempfile.mkdtemp()`][mkdtemp]. By
  default, this is a directory that is created within the `$TMPDIR`. The reason for this
  is that currently, when mykrobe cleans up temporary files, it doesn't remove the
  temporary directory ([#113][113]). I wasn't really comfortable with removing the
  temporary directory in case the user had set it to something like the current
  directory. At least with this default now the temporary directory won't clog up the
  current directory after mykrobe is finished and the OS should clean it up
  periodically.
- Ensure `--memory` and `--threads` are passed on to mccortex [[#114][114]].

[113]: https://github.com/Mykrobe-tools/mykrobe/issues/113
[114]: https://github.com/Mykrobe-tools/mykrobe/issues/114
[Unreleased]: https://github.com/Mykrobe-tools/mykrobe/compare/v0.9.0...HEAD
[mkdtemp]: https://docs.python.org/3.6/library/tempfile.html#tempfile.mkdtemp

