### PR TITLE
Change species and sample positionals into options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- `-o` as another option for `--output`
+- `-i` as another option for `-1,--seq`
+- `-A` as another option for `--report_all_calls`
+- `-e` as another option for `--expected_error_rate`
+
 ### Changed
 
 - If `--tmp` is not specified now, it is set to [`tempfile.mkdtemp()`][mkdtemp]. By
@@ -18,6 +25,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   current directory after mykrobe is finished and the OS should clean it up
   periodically.
 - Ensure `--memory` and `--threads` are passed on to mccortex [[#114][114]].
+- Positional arguments `species` and `sample` are now options `-S,species` and
+  `-s,--sample` respectively.
 
 [113]: https://github.com/Mykrobe-tools/mykrobe/issues/113
 [114]: https://github.com/Mykrobe-tools/mykrobe/issues/114

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Please see the [mykrobe wiki](https://github.com/Mykrobe-tools/mykrobe/wiki) for
 **Run** on Mtb, making a JSON file of results:
 
 ```
-mykrobe predict my_sample_name tb \
+mykrobe predict --sample my_sample_name \
+  --species tb \
   --output out.json \
   --format json \
   --seq reads.fq.gz

--- a/src/mykrobe/base.py
+++ b/src/mykrobe/base.py
@@ -1,166 +1,170 @@
 from __future__ import print_function
-import os
-import argparse
 
+import argparse
+import os
 
 DEFAULT_KMER_SIZE = os.environ.get("KMER_SIZE", 21)
 DEFAULT_DB_NAME = os.environ.get("DB_NAME", "mykrobe")
 
 sequence_or_graph_parser_mixin = argparse.ArgumentParser(add_help=False)
 sequence_or_graph_parser_mixin.add_argument(
-    'sample',
+    "-s", "--sample", required=True, type=str, help="Sample identifier [REQUIRED]"
+)
+sequence_or_graph_parser_mixin.add_argument(
+    "-k",
+    "--kmer",
+    metavar="kmer",
+    type=int,
+    help="K-mer length (default: %(default)d)",
+    default=DEFAULT_KMER_SIZE,
+)
+sequence_or_graph_parser_mixin.add_argument(
+    "--tmp", help="Directory to write temporary files to", default=None
+)
+sequence_or_graph_parser_mixin.add_argument(
+    "--keep_tmp", help="Don't remove temporary files", action="store_true"
+)
+sequence_or_graph_parser_mixin.add_argument(
+    "--skeleton_dir",
+    help="Directory for skeleton binaries",
+    default="mykrobe/data/skeletons/",
+)
+sequence_or_graph_parser_mixin.add_argument(
+    "-t", "--threads", type=int, help="Number of threads to use", default=1
+)
+sequence_or_graph_parser_mixin.add_argument(
+    "-m",
+    "--memory",
     type=str,
-    help='sample id')
+    help="Memory to allocate for graph constuction (default: %(default)s)",
+    default="1GB",
+)
 sequence_or_graph_parser_mixin.add_argument(
-    '-k',
-    '--kmer',
-    metavar='kmer',
-    type=int,
-    help='kmer length (default: %(default)d)',
-    default=DEFAULT_KMER_SIZE)
-sequence_or_graph_parser_mixin.add_argument(
-    '--tmp',
-    help='Directory to write temporary files to',
-    default=None)
-sequence_or_graph_parser_mixin.add_argument(
-    '--keep_tmp',
-    help="Dont remove tmp files",
-    action="store_true")
-sequence_or_graph_parser_mixin.add_argument(
-    '--skeleton_dir',
-    help='directory for skeleton binaries',
-    default="mykrobe/data/skeletons/")
-sequence_or_graph_parser_mixin.add_argument(
-    '-t',
-    '--threads',
-    type=int,
-    help='threads',
-    default=1)
-sequence_or_graph_parser_mixin.add_argument(
-    '-m',
-    '--memory',
-    type=str,
-    help='memory for graph constuction',
-    default="1GB")
-sequence_or_graph_parser_mixin.add_argument(
-    '--expected_depth',
-    type=int,
-    help='expected depth',
-    default=None)
+    "--expected_depth", type=int, help="Expected depth", default=None
+)
 
 
-SEQUENCE_FILES_HELP_STRING = 'sequence files (fasta,fastq,bam)'
-sequence_parser_mixin = argparse.ArgumentParser(
-    parents=[sequence_or_graph_parser_mixin], add_help=False)
-sequence_parser_mixin.add_argument(
-    'seq',
-    type=str,
-    help=SEQUENCE_FILES_HELP_STRING,
-    nargs='+')
+SEQUENCE_FILES_HELP_STRING = "Sequence files (fasta,fastq,bam)"
 
 sequence_or_binary_parser_mixin = argparse.ArgumentParser(
-    parents=[sequence_or_graph_parser_mixin], add_help=False)
+    parents=[sequence_or_graph_parser_mixin], add_help=False
+)
 sequence_or_binary_parser_mixin.add_argument(
-    '-1',
-    '--seq',
-    metavar='seq',
+    "-1",
+    "-i",
+    "--seq",
+    metavar="seq",
     type=str,
-    nargs='+',
-    help=SEQUENCE_FILES_HELP_STRING)
+    nargs="+",
+    help=SEQUENCE_FILES_HELP_STRING,
+)
 sequence_or_binary_parser_mixin.add_argument(
-    '-c',
-    '--ctx',
-    metavar='ctx',
-    type=str,
-    help='cortex graph binary')
+    "-c", "--ctx", metavar="ctx", type=str, help="Cortex graph binary"
+)
 
 probe_set_mixin = argparse.ArgumentParser(add_help=False)
 probe_set_mixin.add_argument(
-    'probe_set',
-    metavar='probe_set',
-    type=str,
-    help='probe_set')
+    "probe_set", metavar="probe_set", type=str, help="probe_set"
+)
 
 force_mixin = argparse.ArgumentParser(add_help=False)
 force_mixin.add_argument(
-    '-f',
-    '--force',
-    action='store_true',
-    help='force')
+    "-f", "--force", action="store_true", help="Force override any skeleton files"
+)
 
 genotyping_mixin = argparse.ArgumentParser(add_help=False)
 genotyping_mixin.add_argument(
-    '--ont',
-    action='store_true',
-    help='Set default for ONT data. Sets expected_error_rate to 0.15 and to haploid')
+    "--ont",
+    action="store_true",
+    help="Set default for ONT data. Sets expected_error_rate to 0.15 and to haploid",
+)
 genotyping_mixin.add_argument(
-    '--guess_sequence_method',
-    action='store_true',
-    help="Guess if ONT or Illumia based on error rate. If error rate is > 10%%, ploidy is set to haploid and a confidence threshold is used ")
+    "--guess_sequence_method",
+    action="store_true",
+    help="Guess if ONT or Illumia based on error rate. If error rate is > 10%%, ploidy is set to haploid and a confidence threshold is used ",
+)
 genotyping_mixin.add_argument(
-    '--ignore_minor_calls',
-    action='store_true',
-    help='Ignore minor calls when running resistance prediction')
+    "--ignore_minor_calls",
+    action="store_true",
+    help="Ignore minor calls when running resistance prediction",
+)
 genotyping_mixin.add_argument(
-    '--ignore_filtered',
-    help="don't include filtered genotypes",
-    default=False)
+    "--ignore_filtered", help="Don't include filtered genotypes", default=False
+)
 genotyping_mixin.add_argument(
-    '--model',
-    metavar='model',
-    choices=['median_depth', 'kmer_count'],
+    "--model",
+    metavar="model",
+    choices=["median_depth", "kmer_count"],
     type=str,
-    help='Genotype model used, default kmer_count. Options kmer_count, median_depth',
-    default='kmer_count')
+    help="Genotype model used. Options kmer_count, median_depth (default: %(default)s)",
+    default="kmer_count",
+)
 genotyping_mixin.add_argument(
-    '--ploidy',
-    metavar='ploidy',
-    choices=['diploid', 'haploid'],
+    "--ploidy",
+    metavar="ploidy",
+    choices=["diploid", "haploid"],
     type=str,
-    help='Use a diploid (includes 0/1 calls) or haploid genotyping model',
-    default='diploid')
+    help="Use a diploid (includes 0/1 calls) or haploid genotyping model (default: %(default)s)",
+    default="diploid",
+)
 genotyping_mixin.add_argument(
-    '--filters',
-    help="don't include filtered genotypes",
-    nargs='+',
+    "--filters",
+    help="Don't include specific filtered genotypes (default: %(default)s)",
+    nargs="+",
     default=["MISSING_WT", "LOW_PERCENT_COVERAGE", "LOW_GT_CONF", "LOW_TOTAL_DEPTH"],
-    required=False)
+    required=False,
+)
 genotyping_mixin.add_argument(
-    '--report_all_calls',
-    help="report all calls",
-    action='store_true',
-    default=False)
+    "-A",
+    "--report_all_calls",
+    help="Report all calls",
+    action="store_true",
+    default=False,
+)
 genotyping_mixin.add_argument(
+    "-e",
     "--expected_error_rate",
-    help="Expected sequencing error rate. Set to 0.15 for ONT genotyping.",
-    default=0.05, type=float)
+    help="Expected sequencing error rate (default: %(default).2f)",
+    default=0.05,
+    type=float,
+)
 genotyping_mixin.add_argument(
     "--min_variant_conf",
-    help="minimum genotype confidence for variant genotyping",
-    default=150, type=int)
+    help="Minimum genotype confidence for variant genotyping (default: %(default)d)",
+    default=150,
+    type=int,
+)
 genotyping_mixin.add_argument(
     "--min_gene_conf",
-    help="minimum genotype confidence for gene genotyping",
-    default=1, type=int)
+    help="Minimum genotype confidence for gene genotyping (default: %(default)d)",
+    default=1,
+    type=int,
+)
 genotyping_mixin.add_argument(
     "--min_proportion_expected_depth",
-    help="minimum depth required on the sum of both alleles. Default 0.3 (30%%)",
-    default=0.3, type=float)
+    help="Minimum depth required on the sum of both alleles (default: %(default).2f)",
+    default=0.3,
+    type=float,
+)
 genotyping_mixin.add_argument(
     "--min_gene_percent_covg_threshold",
-    help="all genes alleles found above this percent coverage will be reported (default 100 (only best alleles reported))",
-    default=100, type=int)
+    help="All genes alleles found above this percent coverage will be reported (default: %(default)d (only best alleles reported))",
+    default=100,
+    type=int,
+)
 genotyping_mixin.add_argument(
-    '--output',
+    "-o",
+    "--output",
     type=str,
-    help='File path to save output json file as. Default is to stdout.',
-    default='')
+    help="File path to save output json file as. Default is to stdout",
+    default="",
+)
 
 
 panels_mixin = argparse.ArgumentParser(add_help=False)
 panels_mixin.add_argument(
     "--panels_dir",
     metavar="DIRNAME",
-    help="Name of directory that contains panel data. Default: %(default)s",
+    help="Name of directory that contains panel data (default: %(default)s)",
     default=os.path.abspath(os.path.join(os.path.dirname(__file__), "data")),
 )

--- a/src/mykrobe/parser.py
+++ b/src/mykrobe/parser.py
@@ -278,19 +278,6 @@ parser_dump.add_argument(
 parser_dump.add_argument("-v", "--verbose", default=False, action="store_true")
 parser_dump.set_defaults(func=run_subtool)
 
-# parser_add_gt = subparsers.add_parser(
-#     'add-gt',
-#     help='adds a set of atlas genotype calls to the atlas',
-#     parents=[db_parser_mixin, force_mixin])
-# parser_add_gt.add_argument('jsons', type=str, nargs='+',
-#                            help='json output from `atlas genotype`')
-# parser_add_gt.add_argument(
-#     '-m',
-#     '--method',
-#     type=str,
-#     help='variant caller method (e.g. CORTEX)',
-#     default="atlas")
-# parser_add_gt.set_defaults(func=run_subtool)
 
 # ##################
 # ### Make Probes ##
@@ -335,23 +322,3 @@ parser_make_probes.add_argument(
     "--lineage", type=str, help="Write lineages to output file", metavar="FILENAME",
 )
 parser_make_probes.set_defaults(func=run_subtool)
-
-# ##########
-# # Genotype
-# ##########
-# parser_geno = subparsers.add_parser(
-#    "genotype",
-#    parents=[
-#        sequence_or_binary_parser_mixin,
-#        probe_set_mixin,
-#        force_mixin,
-#        genotyping_mixin,
-#    ],
-#    help="genotype a sample using a probe set",
-# )
-# parser_geno.add_argument(
-#    "--lineage",
-#    type=str,
-#    help="Input JSON file of lineages (made by make-probes --lineage)",
-#    metavar="FILENAME")
-# parser_geno.set_defaults(func=run_subtool)


### PR DESCRIPTION
`species` and `sample` being positional arguments has caused me a lot of grief in the past. It can also produce very cryptic error messages that can take a while to decipher.  
The issue lies with the combination of options that are `nargs="+"` and the positional arguments. For example

```
$ mykrobe predict --seq r1.fq r2.fq sample species
```

returns the following error message

```
mykrobe predict: error: the following arguments are required: sample, species
```

What is happening here is that because `--seq` has `nargs="+"` "all command-line args present are gathered into a list." Meaning `--seq` captures the following for its input `["r1.fq", "r2.fq", "sample", "species"]` leaving nothing for the positional arguments. This is pretty annoying behaviour from argparse.  
The best way I could think of to solve this was to just turn the positionals into options `--species` and `--sample` (and make them required). I actually also like this as I always forget which order they're supposed to be in when they're positionally passed.
I also make some minor changes to text in help messages and added a few shortcut options for some options I commonly use.

Happy to take suggestions and tweak the behaviour too. This will also mean the next release will need to be a minor version bump to v0.10.0.

### Added

- `-o` as another option for `--output`
- `-i` as another option for `-1,--seq`
- `-A` as another option for `--report_all_calls`
- `-e` as another option for `--expected_error_rate` 

### Changed 

- Positional arguments `species` and `sample` are now options `-S,species` and
  `-s,--sample` respectively.