### PR TITLE
Update Travis build macOS version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ jobs:
     env:
     - TOXENV=py3
     before_install:
-    - brew uninstall --cask --force java
+    - brew uninstall --force java
     - brew update
     - brew tap mongodb/brew
     - brew install mongodb-community

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ jobs:
     env:
     - TOXENV=py3
     before_install:
+    - brew uninstall --cask --force java
     - brew update
     - brew tap mongodb/brew
     - brew install mongodb-community

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,12 @@ jobs:
 
   - name: OSX Python default version
     os: osx
+    osx_image: xcode11.3
     language: shell
     env:
     - TOXENV=py3
     before_install:
+    - brew update
     - brew tap mongodb/brew
     - brew install mongodb-community
     - sudo mkdir -p /data/db

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,7 @@ jobs:
     env:
     - TOXENV=py3
     before_install:
-    - brew uninstall --force java
-    - brew update
+    - travis_wait 30 brew update
     - brew tap mongodb/brew
     - brew install mongodb-community
     - sudo mkdir -p /data/db

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ jobs:
     env:
     - TOXENV=py3
     before_install:
-    - travis_wait 30 brew update
     - brew tap mongodb/brew
     - brew install mongodb-community
     - sudo mkdir -p /data/db


### PR DESCRIPTION
Previously we are using the default macOS 10.13 in Travis build. Since Apple has discontinued support for this version we started recently seeing OSX build failure due to timeout when executing `brew update`. 

This PR updates the macOS version to 10.14.6 and fixes the OSX build failure issue.