### PR TITLE
Add mccortex build step to Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,4 +119,5 @@ test-probes.txt
 z.test.pncA_T2ATAC.txt
 
 .idea
+src/mykrobe/cortex/mccortex31
 .mongodb

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,12 +31,13 @@ ARG PROJECT="mykrobe"
 COPY . "/${PROJECT}"
 
 # install mccortex
-#WORKDIR "/tmp"
-#
-#RUN git clone --recursive -b geno_kmer_count https://github.com/phelimb/mccortex \
-#    && cd mccortex \
-#    && make MAXK=31 \
-#    && cp bin/mccortex31 /${PROJECT}/src/mykrobe/cortex/
+WORKDIR "/tmp"
+
+RUN git clone --recursive -b geno_kmer_count https://github.com/phelimb/mccortex \
+    && cd mccortex \
+    && make MAXK=31 \
+    && cp bin/mccortex31 /${PROJECT}/src/mykrobe/cortex/ \
+    && rm -rf /tmp/mccortex
 
 # install mykrobe
 WORKDIR "/${PROJECT}"


### PR DESCRIPTION
I don't know how this happened, but basically mccortex wasn't being installed in the docker image. I had tested it locally, but I think it must have pulled my local copy of mccortex into the container. Then when I tried to use the image from quay it didn't work. I have now tested that the images build on quay from this recipe **do** have mccortex in there and work as expected.

Also added the mccortex binary to gitignore so we don't accidentally add it.