### PR TITLE
Lineage call use presence probes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -193,6 +193,7 @@ jobs:
         echo "pip install ."
         C:\\msys64\\mingw64\\bin\\python3.exe -m pip install .
         echo "pytest"
+        export MYKROBE_MCCORTEX="${PWD}/mccortex/bin/mccortex31"
         C:\\msys64\\mingw64\\bin\\python3.exe -m pytest
         echo "update panels"
         C:\\msys64/mingw64/bin/mykrobe.exe panels update_metadata --panels_dir src/mykrobe/data

--- a/src/mykrobe/__init__.py
+++ b/src/mykrobe/__init__.py
@@ -1,2 +1,4 @@
 from mykrobe import version
 from mykrobe.constants import *
+from mykrobe.cmds import *
+from mykrobe import cli

--- a/src/mykrobe/cmds/__init__.py
+++ b/src/mykrobe/cmds/__init__.py
@@ -1,0 +1,1 @@
+from mykrobe.cmds import amr, panels

--- a/src/mykrobe/cmds/amr.py
+++ b/src/mykrobe/cmds/amr.py
@@ -98,8 +98,10 @@ class ConfThresholder:
             ) + 0.01  #  see KmerCountGenotypeModel.depth_to_expected_kmer_count()
 
             correct_percent_coverage = 100
-            incorrect_percent_coverage = ConfThresholder._get_incorrect_kmer_percent_cov(
-                int(incorrect_k_count), self.incorrect_kmer_to_pc_cov
+            incorrect_percent_coverage = (
+                ConfThresholder._get_incorrect_kmer_percent_cov(
+                    int(incorrect_k_count), self.incorrect_kmer_to_pc_cov
+                )
             )
             correct_probe_coverage = ProbeCoverage(
                 correct_percent_coverage,
@@ -250,7 +252,6 @@ def fix_X_amino_acid_variants(sample_json):
 def run(parser, args):
     logger.info(f"Start runnning mykrobe predict. Command line: {' '.join(sys.argv)}")
     base_json = {args.sample: {}}
-    args = parser.parse_args()
     ref_data = ref_data_from_args(args)
     if (
         args.species == "custom"
@@ -270,7 +271,9 @@ def run(parser, args):
 
     if args.ont:
         args.expected_error_rate = ONT_E_RATE
-        logger.info(f"Set expected error rate to {args.expected_error_rate} because --ont flag was used")
+        logger.info(
+            f"Set expected error rate to {args.expected_error_rate} because --ont flag was used"
+        )
         args.ploidy = ONT_PLOIDY
         logger.info(f"Set ploidy to {args.ploidy} because --ont flag used")
 
@@ -285,7 +288,7 @@ def run(parser, args):
         verbose=False,
         tmp_dir=args.tmp,
         skeleton_dir=args.skeleton_dir,
-        memory=args.memory
+        memory=args.memory,
     )
     cp.run()
     logger.debug("CoverageParser complete")
@@ -435,7 +438,7 @@ def run(parser, args):
         "version": {
             "mykrobe-predictor": predictor_version,
             "mykrobe-atlas": atlas_version,
-            "panel": ref_data["version"]
+            "panel": ref_data["version"],
         },
         "genotype_model": args.model,
     }

--- a/src/mykrobe/cmds/panels.py
+++ b/src/mykrobe/cmds/panels.py
@@ -4,18 +4,15 @@ logger = logging.getLogger(__name__)
 from mykrobe.species_data import DataDir
 
 def describe(parser, args):
-    args = parser.parse_args()
     ddir = DataDir(args.panels_dir)
     print(f"Gathering data from {ddir.root_dir}")
     ddir.print_panels_summary()
 
 def update_metadata(parser, args):
-    args = parser.parse_args()
     ddir = DataDir(args.panels_dir)
     ddir.update_manifest(filename=args.filename)
 
 def update_species(parser, args):
-    args = parser.parse_args()
     ddir = DataDir(args.panels_dir)
     logger.info(f"Loaded panels metdata from {ddir.root_dir}")
 

--- a/src/mykrobe/constants.py
+++ b/src/mykrobe/constants.py
@@ -10,3 +10,4 @@ NON_METADATA_KEYS = {"INFO", "FILTER", "ALT", "FORMAT", "contig"}
 # Spec is a bit weak on which metadata lines are singular, like fileformat
 # and which can have repeats, like contig
 SINGULAR_METADATA = {'fileformat', 'fileDate', 'reference'}
+MCCORTEX_BINARY_ENV_VAR = "MYKROBE_MCCORTEX"

--- a/src/mykrobe/cortex/mccortex.py
+++ b/src/mykrobe/cortex/mccortex.py
@@ -5,7 +5,7 @@ import subprocess
 import logging
 import tempfile
 
-from mykrobe import K
+from mykrobe import K, MCCORTEX_BINARY_ENV_VAR
 
 logger = logging.getLogger(__name__)
 
@@ -43,8 +43,8 @@ def syscall(command):
 
 class McCortexRunner(object):
     def __init__(self):
-        if "MYKROBE_MCCORTEX" in os.environ:
-            self.mccortex31_path = os.environ["MYKROBE_MCCORTEX"]
+        if MCCORTEX_BINARY_ENV_VAR in os.environ:
+            self.mccortex31_path = os.environ[MCCORTEX_BINARY_ENV_VAR]
         else:
             dir_of_this_file = os.path.dirname(os.path.abspath(__file__))
             self.mccortex31_path = os.path.join(dir_of_this_file, "mccortex31")

--- a/src/mykrobe/cortex/mccortex.py
+++ b/src/mykrobe/cortex/mccortex.py
@@ -40,55 +40,59 @@ def syscall(command):
     logger.debug(f"stderr:\n{completed_process.stderr.rstrip()}")
     return completed_process
 
-class McCortexRunner(object):
 
+class McCortexRunner(object):
     def __init__(self):
-        dir_of_this_file = os.path.dirname(os.path.abspath(__file__))
-        self.mccortex31_path = os.path.join(dir_of_this_file, "mccortex31")
+        if "MYKROBE_MCCORTEX" in os.environ:
+            self.mccortex31_path = os.environ["MYKROBE_MCCORTEX"]
+        else:
+            dir_of_this_file = os.path.dirname(os.path.abspath(__file__))
+            self.mccortex31_path = os.path.join(dir_of_this_file, "mccortex31")
+
         if os.path.exists(self.mccortex31_path):
             pass
         elif os.path.exists(self.mccortex31_path + ".exe"):
             self.mccortex31_path += ".exe"
         else:
-            raise RuntimeError(f"Did not find mccortex31. Expected it to be here: {self.mccortex31_path}. Cannot continue")
+            raise RuntimeError(
+                f"Did not find mccortex31. Expected it to be here: {self.mccortex31_path}. Cannot continue"
+            )
         logger.debug(f"Found mccortex31: {self.mccortex31_path}")
 
 
 class McCortexJoin(McCortexRunner):
-
     def __init__(
-            self,
-            sample,
-            intersect_graph,
-            ingraph,
-        ):
+        self,
+        sample,
+        intersect_graph,
+        ingraph,
+    ):
         super(McCortexJoin, self).__init__()
         self.sample = sample
         self.intersect_graph = intersect_graph
         self.ingraph = ingraph
         self.out_ctx_dir = tempfile.mkdtemp()
-        self.out_ctx_path = os.path.join(
-            self.out_ctx_dir,
-            "%s_int.ctx" %
-            sample)
+        self.out_ctx_path = os.path.join(self.out_ctx_dir, "%s_int.ctx" % sample)
 
     def run(self):
         self._run_cortex()
         return self.out_ctx_path
 
     def _run_cortex(self):
-        cmd = [self.mccortex31_path,
-               "join",
-               "-q",
-               "--out", self.out_ctx_path,
-               "--intersect",
-               self.intersect_graph,
-               self.ingraph]
+        cmd = [
+            self.mccortex31_path,
+            "join",
+            "-q",
+            "--out",
+            self.out_ctx_path,
+            "--intersect",
+            self.intersect_graph,
+            self.ingraph,
+        ]
         syscall(cmd)
 
 
 class McCortexUnitigs(McCortexRunner):
-
     def __init__(self, ingraph):
         super(McCortexUnitigs, self).__init__()
         self.ingraph = ingraph
@@ -97,22 +101,18 @@ class McCortexUnitigs(McCortexRunner):
         return self._run_cortex()
 
     def _run_cortex(self):
-        cmd = [self.mccortex31_path,
-               "unitigs",
-               "-q",
-               self.ingraph]
+        cmd = [self.mccortex31_path, "unitigs", "-q", self.ingraph]
         return syscall(cmd)
 
 
 class McCortexSubgraph(McCortexRunner):
-
     def __init__(
-            self,
-            sample,
-            rmgraph,
-            ingraph,
-            tmp_dir=None,
-        ):
+        self,
+        sample,
+        rmgraph,
+        ingraph,
+        tmp_dir=None,
+    ):
         super(McCortexSubgraph, self).__init__()
         self.rmgraph = rmgraph
         self.sample = sample
@@ -121,56 +121,53 @@ class McCortexSubgraph(McCortexRunner):
             self.out_ctx_dir = tempfile.mkdtemp()
         else:
             self.out_ctx_dir = tmp_dir
-        self.out_ctx_path = os.path.join(
-            self.out_ctx_dir,
-            "%s_new.ctx" %
-            sample)
+        self.out_ctx_path = os.path.join(self.out_ctx_dir, "%s_new.ctx" % sample)
 
     def run(self):
         self._run_cortex()
         return self.out_ctx_path
 
     def _run_cortex(self):
-        cmd = [self.mccortex31_path,
-               "view",
-               "-q",
-               "-k",
-               self.rmgraph,
-               "|",
-               "awk",
-               "'{print $1}'",
-               "|",
-               self.mccortex31_path,
-               "subgraph",
-               "-q",
-               "--out",
-               self.out_ctx_path,
-               "--invert",
-               "--seq",
-               "-",
-               self.ingraph
-               ]
+        cmd = [
+            self.mccortex31_path,
+            "view",
+            "-q",
+            "-k",
+            self.rmgraph,
+            "|",
+            "awk",
+            "'{print $1}'",
+            "|",
+            self.mccortex31_path,
+            "subgraph",
+            "-q",
+            "--out",
+            self.out_ctx_path,
+            "--invert",
+            "--seq",
+            "-",
+            self.ingraph,
+        ]
         logger.debug(subprocess.list2cmdline(cmd))
         logger.debug(" ".join(cmd))
         syscall(cmd)
 
 
 class McCortexGenoRunner(McCortexRunner):
-
     def __init__(
-            self,
-            sample,
-            panels,
-            seq=None,
-            ctx=None,
-            kmer=K,
-            threads=2,
-            memory="1GB",
-            force=False,
-            panel_name=None,
-            tmp_dir='tmp/',
-            skeleton_dir='data/skeletons/',
-        ):
+        self,
+        sample,
+        panels,
+        seq=None,
+        ctx=None,
+        kmer=K,
+        threads=2,
+        memory="1GB",
+        force=False,
+        panel_name=None,
+        tmp_dir="tmp/",
+        skeleton_dir="data/skeletons/",
+    ):
         super(McCortexGenoRunner, self).__init__()
         self.sample = sample
         self.panels = panels
@@ -191,16 +188,16 @@ class McCortexGenoRunner(McCortexRunner):
             self._check_panels()
             self._run_cortex()
         else:
-            logger.warning('Not running mccortex. '
-                           'Force flag is false and coverage temp file exists')
+            logger.warning(
+                "Not running mccortex. "
+                "Force flag is false and coverage temp file exists"
+            )
 
     def _check_panels(self):
         # If panel does not exists then build it
         for panel in self.panels:
             if not os.path.exists(panel.filepath):
-                raise ValueError(
-                    "Could not find a panel at %s." %
-                    panel.filepath)
+                raise ValueError("Could not find a panel at %s." % panel.filepath)
 
     def _run_cortex(self):
         # If ctx binary does not exist then build it
@@ -214,14 +211,21 @@ class McCortexGenoRunner(McCortexRunner):
                 os.remove(self.ctx_skeleton_filepath)
             # panel
             seq_list = self._create_sequence_list()
-            cmd = [self.mccortex31_path,
-                   "build",
-                   "-q",
-                   "-m %s" % self.memory,
-                   "-t", "%i" % self.threads,
-                   "-k",
-                   str(self.kmer)] + seq_list + [self.ctx_skeleton_filepath]
-            logger.debug('Executing command:\n%s', cmd)
+            cmd = (
+                [
+                    self.mccortex31_path,
+                    "build",
+                    "-q",
+                    "-m %s" % self.memory,
+                    "-t",
+                    "%i" % self.threads,
+                    "-k",
+                    str(self.kmer),
+                ]
+                + seq_list
+                + [self.ctx_skeleton_filepath]
+            )
+            logger.debug("Executing command:\n%s", cmd)
             syscall(cmd)
 
     def _create_sequence_list(self):
@@ -233,8 +237,7 @@ class McCortexGenoRunner(McCortexRunner):
 
     @staticmethod
     def _execute_command(command):
-        process = subprocess.Popen(command,
-                                   stdout=subprocess.PIPE)
+        process = subprocess.Popen(command, stdout=subprocess.PIPE)
 
         while True:
             nextline = process.stdout.readline()
@@ -250,9 +253,11 @@ class McCortexGenoRunner(McCortexRunner):
             raise subprocess.CalledProcessError
 
     def _run_coverage_if_required(self):
-        if not os.path.exists(
-                self.ctx_tmp_filepath) or not os.path.exists(
-                self.covg_tmp_file_path) or self.force:
+        if (
+            not os.path.exists(self.ctx_tmp_filepath)
+            or not os.path.exists(self.covg_tmp_file_path)
+            or self.force
+        ):
             if os.path.exists(self.ctx_tmp_filepath):
                 os.remove(self.ctx_tmp_filepath)
             if os.path.exists(self.covg_tmp_file_path):
@@ -260,8 +265,10 @@ class McCortexGenoRunner(McCortexRunner):
 
             syscall(self.coverages_cmd)
         else:
-            logger.warning('Using pre-built binaries. Run with --force if '
-                           'panel has been updated.')
+            logger.warning(
+                "Using pre-built binaries. Run with --force if "
+                "panel has been updated."
+            )
 
     @property
     def coverages_cmd(self):
@@ -274,13 +281,17 @@ class McCortexGenoRunner(McCortexRunner):
 
     @property
     def base_geno_command(self):
-        return [self.mccortex31_path,
-                "geno",
-                "-t",
-                "%i" % self.threads,
-                "-m %s" % self.memory,
-                "-k", str(self.kmer),
-                "-o", self.covg_tmp_file_path]
+        return [
+            self.mccortex31_path,
+            "geno",
+            "-t",
+            "%i" % self.threads,
+            "-m %s" % self.memory,
+            "-k",
+            str(self.kmer),
+            "-o",
+            self.covg_tmp_file_path,
+        ]
 
     @property
     def coverages_cmd_seq(self):
@@ -310,8 +321,7 @@ class McCortexGenoRunner(McCortexRunner):
     @property
     def panel_name(self):
         if self._panel_name is None:
-            self._panel_name = "-".join([p.name.replace('/', '-')
-                                         for p in self.panels])
+            self._panel_name = "-".join([p.name.replace("/", "-") for p in self.panels])
         return self._panel_name
 
     @property
@@ -320,19 +330,20 @@ class McCortexGenoRunner(McCortexRunner):
 
     @property
     def ctx_tmp_filepath(self):
-        sample_panel_name = self.sample_panel_name + '.ctx'
+        sample_panel_name = self.sample_panel_name + ".ctx"
         return os.path.join(self.tmp_dir, sample_panel_name)
 
     @property
     def covg_tmp_file_path(self):
-        sample_panel_name = self.sample_panel_name + '.covgs'
+        sample_panel_name = self.sample_panel_name + ".covgs"
         return os.path.join(self.tmp_dir, sample_panel_name)
 
     @property
     def ctx_skeleton_filepath(self):
         panel_name = self.panel_name.replace("/", "-")[:100]
-        panel_fname = '{panel_name}_{kmer}.ctx'.format(panel_name=panel_name,
-                                                       kmer=self.kmer)
+        panel_fname = "{panel_name}_{kmer}.ctx".format(
+            panel_name=panel_name, kmer=self.kmer
+        )
         return os.path.join(self.skeleton_dir, panel_fname)
 
     def remove_temporary_files(self):

--- a/tests/end_to_end_test.py
+++ b/tests/end_to_end_test.py
@@ -1,0 +1,98 @@
+import json
+import os
+import pytest
+import subprocess
+
+from mykrobe.parser import parser
+import mykrobe
+
+
+def test_get_panels_and_run_predict_on_test_reads():
+    # This is a basic end-to-end test using the Mtb test reads that are on
+    # figshare. We'll run mykrobe predict on the reads, and check we get
+    # INH resistance, and that the lineage call is 4.10.
+    # This means downloading the panel data, downloading the reads, running
+    # mykrobe predict, and checking the relevant parts of the JSON output file.
+    # Note: not calling this via subprocess because we want to get an
+    # accurate coverage report.
+    out_dir = "test.myk_tb_end_to_end"
+    subprocess.check_output(f"rm -rf {out_dir}", shell=True)
+    os.mkdir(out_dir)
+
+    # Test we can download the panels ok, and basic check we got TB and the
+    # panel we want to use
+    panels_dir = os.path.join(out_dir, "panels")
+    args = parser.parse_args(["panels", "update_metadata", "--panels_dir", panels_dir])
+    mykrobe.cmds.panels.update_metadata(parser, args)
+    args = parser.parse_args(
+        ["panels", "update_species", "--panels_dir", panels_dir, "all"]
+    )
+    mykrobe.cmds.panels.update_species(parser, args)
+    panels_json = os.path.join(panels_dir, "manifest.json")
+    assert os.path.exists(panels_json)
+    with open(panels_json) as f:
+        panels_manifest = json.load(f)
+    assert "tb" in panels_manifest
+    tb_json = os.path.join(panels_dir, "tb", "manifest.json")
+    assert os.path.exists(tb_json)
+    with open(tb_json) as f:
+        tb_manifest = json.load(f)
+    panel_to_use = "202010"
+    assert "panels" in tb_manifest
+    assert panel_to_use in tb_manifest["panels"]
+
+    # Get the test reads from figshare and run predict on them
+    reads_fq = os.path.join(out_dir, "reads.fq.gz")
+    predict_json = os.path.join(out_dir, "predict.json")
+    if os.path.exists(predict_json):
+        os.unlink(predict_json)
+    subprocess.check_output(
+        f"wget -q -O {reads_fq} https://ndownloader.figshare.com/files/21059229",
+        shell=True,
+    )
+    sample_name = "TEST_SAMPLE"
+    # Important! We need to use a different name for the skeletons directory,
+    # because the default mykrobe/data/skeletons breaks with the coverage
+    # module, resulting in no coverage report.
+    skeleton_dir = os.path.join(out_dir, "skeletons")
+    args = parser.parse_args(
+        [
+            "predict",
+            "--panel",
+            panel_to_use,
+            "--skeleton_dir",
+            skeleton_dir,
+            "--sample",
+            sample_name,
+            "--species",
+            "tb",
+            "--format",
+            "json",
+            "--output",
+            predict_json,
+            "--seq",
+            reads_fq,
+            "--panels_dir",
+            panels_dir,
+        ]
+    )
+    mykrobe.cmds.amr.run(parser, args)
+
+    # Basic checks of the results:
+    # - we got a JSON file
+    # - there's one sample in the json, with the expected name
+    # - all drugs susceptible, except isoniazid should be resistant
+    # - lineage is 4.10.
+    with open(predict_json) as f:
+        amr_results = json.load(f)
+    assert len(amr_results) == 1
+    assert sample_name in amr_results
+    for drug, results in amr_results[sample_name]["susceptibility"].items():
+        if drug == "Isoniazid":
+            assert results["predict"] == "R"
+        else:
+            assert results["predict"] == "S"
+    assert amr_results[sample_name]["phylogenetics"]["lineage"]["lineage"] == [
+        "lineage4.10"
+    ]
+    subprocess.check_output(f"rm -rf {out_dir}", shell=True)

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,8 @@ whitelist_externals=
 	/usr/local/bin/wget
 	/usr/local/bin/cp
 	/usr/local/bin/tar
-setenv = TOX_INI_DIR = {toxinidir}
+setenv =
+    TOX_INI_DIR = {toxinidir}
+    MYKROBE_MCCORTEX = {toxinidir}/mccortex/bin/mccortex31
 commands=
 	pytest --cov-report term-missing --cov=mykrobe {posargs}


### PR DESCRIPTION
This is intended for incoming TB panel update, which will have a fix for calling Bovis/BCG (issue #147).

The current lineage calling only uses SNPs. We need to test for the presence of a sequence to decide if a Bovis sample is also the sub-lineage BCG. When making presence/absence calls for presence probes, this PR add a check if each probe is also a lineage calling probe and uses it if so. So when we update the panel, a new BCG probe can be used to call the lineage.

Also, added an end to end test of downloading the panels and then running mykrobe predict on the test reads from figshare. Because e.g. `genotyper.py` has no unit tests. This needed two changes:
1.  use an environment variable to the path to `mccortex31` binary. This is a workaround for `tox` missing the `mccortex31` binary when it installs mykrobe in its virtualenv.
2. Small changes to init files and stopping the command line args parsing being forced to read from `sys.argv` (twice!). This is so the tests can import and run the high-level functions without resorting to subprocess (which would lose test coverage info).

There's not actually many changes (mostly in `genotyper.py` and adding tests) - running `black` has made this bigger than it looks.