### PR TITLE
Require lineage path support from >50% of nodes, instead of >=50%

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -167,7 +167,7 @@ jobs:
       env:
         OUTPUT_TARBALL: mykrobe.command_line.windows.${{env.RELEASE_VERSION}}.tar.gz
       run: |
-        export PYTHONPATH="/mingw64/lib/python3.9/:/mingw64/lib/python3.9/site-packages:${PYTHONPATH}"
+        export PYTHONPATH="/mingw64/lib/python3.10/:/mingw64/lib/python3.10/site-packages:${PYTHONPATH}"
         C:\\msys64\\mingw64\\bin\\python3.exe -m pip install pyinstaller requests pytest
 
         echo "clone mccortex"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ PyVCF3>=1.0.3
 requests>=2.27.1
 mongoengine>=0.24.1
 cython>=0.29.28
-numpy==1.22.0
+numpy>=1.22.0
 ## Testing
 tox
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ PyVCF3>=1.0.3
 requests>=2.27.1
 mongoengine>=0.24.1
 cython>=0.29.28
-numpy==1.21.5
+numpy==1.22.0
 ## Testing
 tox
 pytest

--- a/src/mykrobe/metagenomics/lineages.py
+++ b/src/mykrobe/metagenomics/lineages.py
@@ -151,7 +151,7 @@ class LineagePredictor:
                 path_leaf = path_leaf.parent
 
             number_good_nodes = len([x for x in path_genos if x[1] > 0])
-            if len(path_genos) == 0 or number_good_nodes / len(path_genos) < min_frac_called or path_leaf.name in paths:
+            if len(path_genos) == 0 or number_good_nodes / len(path_genos) <= min_frac_called or path_leaf.name in paths:
                 continue
 
             # We could end up having say [l1, l1.1, l1.1.2], and also just


### PR DESCRIPTION
This fixes one false-positive lineage call on our lineage test samples (https://github.com/Mykrobe-tools/mykrobe-lineage-test). ERR970409 was getting called as BCG instead of A1. All other test samples still ok with or without this fix.

The change is to need more than half the nodes in the path from the lineage tree to be ok, instead of >= half ok.