### PR TITLE
Ignore duplicate X mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 
 - Loading JSON files will now handled (gzip) compressed files.
+- When an X mutation resolves to an existing variant in the panel, instead of
+  raising an error, do not output the X mutation. This means can still use
+  Walker-2015 panel.
 
 ## 0.11.0
 

--- a/src/mykrobe/utils.py
+++ b/src/mykrobe/utils.py
@@ -161,15 +161,22 @@ def fix_amino_acid_X_variants_keys(dict_to_fix):
     know the actual change. This function changes all keys in dict_to_fix that
     have those variants, changing the X to the actual amino acid."""
     keys_to_replace = {}
+    # Can have a situation where we have an X variant but it resolves
+    # to a variant that is already in the panel. For example
+    # embB_M306X-ATG4247429ATA resolves to embB_M306I-ATG4247429ATA.
+    # Those are both in the Walker-2015 panel. We can remove the
+    # X mutation in this case.
+    keys_to_remove = set()
     for key in dict_to_fix:
         new_key = _x_mutation_fixed_var_name(key)
         if new_key is not None:
             if new_key in keys_to_replace or new_key in dict_to_fix:
-                raise KeyError(
-                    f"The 'X' amino acid in mutation {key}, resolves to {new_key}, "
-                    f"which already exists in the panel"
-                )
-            keys_to_replace[key] = new_key
+                keys_to_remove.add(key)
+            else:
+                keys_to_replace[key] = new_key
+
+    for key in keys_to_remove:
+        del dict_to_fix[key]
 
     for key, new_key in keys_to_replace.items():
         dict_to_fix[new_key] = dict_to_fix[key]

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -54,6 +54,8 @@ def test_fix_amino_acid_X_variants_keys():
         "katG_S315X-GCT2155167GGT": "baz",
         "katG_S315C-GCT2155167TTA": "baz",
         "katG_S315X-GCT2155167CTA": "baz",  # katG is on reverse strand so stop TAG is CTA
+        "embB_M306I-ATG4247429ATA": "value",
+        "embB_M306X-ATG4247429ATA": "value", # duplicate of previous, should remove
     }
 
     utils.fix_amino_acid_X_variants_keys(test_dict)
@@ -62,18 +64,8 @@ def test_fix_amino_acid_X_variants_keys():
         "katG_S315T-GCT2155167GGT": "baz",
         "katG_S315C-GCT2155167TTA": "baz",
         "katG_S315*-GCT2155167CTA": "baz",
+        "embB_M306I-ATG4247429ATA": "value",
     }
-
-
-def test_fix_amino_acid_X_variants_keys_duplicate_raises_error():
-    test_dict = {
-        "ddn_W88X-TGG3987105AGA": "value",
-        "ddn_W88R-TGG3987105AGA": "value",
-    }
-
-    with pytest.raises(KeyError) as err:
-        utils.fix_amino_acid_X_variants_keys(test_dict)
-        assert "ddn_W88X" in err
 
 
 def test_get_first_chrom_name_not_fasta_raises_error():


### PR DESCRIPTION
Instead of raising an error, when we get an X mutation that resolves to an existing mutation in the panel, ignore that X mutation. This case was getting hit in walker-2015 panel, stopping it from being able to be used.