### PR TITLE
Add support for targeted sequencing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- option to compress JSON output (`-z`/`--compress`)
+
 ## 0.12.1
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - option to compress JSON output (`-z`/`--compress`)
+- specific support for targeted sequencing (`-T`/`--targeted`). Takes a BED file of the regions targeted to aid in the read depth estimation [[#28][28]]
+- The script `scripts/combine.py` to combine mykrobe reports into a single CSV file
 
 ## 0.12.1
 
@@ -92,6 +94,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Bug reporting variants that are "amino acid to any other amino acid" changes,
   eg `katG_S315X`. If gene is on reverse strand, then the wrong new amino
   acid change was being reported [[#127][127]].
+
+[28]: https://github.com/Mykrobe-tools/mykrobe/issues/28
 
 [113]: https://github.com/Mykrobe-tools/mykrobe/issues/113
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,12 +41,13 @@ RUN git clone --recursive -b geno_kmer_count https://github.com/phelimb/mccortex
 
 # install mykrobe
 WORKDIR "/${PROJECT}"
-RUN python -m pip install requests && python -m pip install . -vv
+RUN python -m pip install requests \
+    && python -m pip install . -vv \
+    && chmod +x /${PROJECT}/scripts/combine.py
 
 # download panels
 RUN mykrobe panels update_metadata \
     && mykrobe panels update_species all
 
 # add combine script to path \
-COPY --chmod=755 ./scripts/combine.py "/${PROJECT}/scripts/combine.py"
 ENV PATH="/${PROJECT}/scripts:$PATH"

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,3 +46,7 @@ RUN python -m pip install requests && python -m pip install . -vv
 # download panels
 RUN mykrobe panels update_metadata \
     && mykrobe panels update_species all
+
+# add combine script to path \
+COPY --chmod=755 ./scripts/combine.py "/${PROJECT}/scripts/combine.py"
+ENV PATH="/${PROJECT}/scripts:$PATH"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ requests>=2.27.1
 mongoengine>=0.24.1
 cython>=0.29.28
 numpy>=1.22.0
+intervaltree~=3.1
 ## Testing
 tox
 pytest

--- a/scripts/combine.py
+++ b/scripts/combine.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""This script can be used to combine multiple mykrobe CSV/JSON output files into a
+a sheet for easy comparison. The columns are drugs, the rows are samples, and the cells
+are the susceptibility prediction.
+
+USAGE:
+
+# combine two CSV reports into a file called samples.csv
+combine.py -o samples.csv sample1.csv sample2.csv
+
+# combine a JSON report with a CSV report
+combine.py -o samples.csv sample1.json sample2.csv
+
+# combine all JSON and CSV files in a directory
+combine.py -o samples.csv reports/
+"""
+import json
+import sys
+import argparse
+from pathlib import Path
+from typing import Dict
+
+
+def extract_csv_data(path: Path) -> Dict[str, str]:
+    report = dict()
+    with open(path) as fp:
+        header_fields = [s.strip('"') for s in next(fp).split(",")]
+        sample_idx = header_fields.index("sample")
+        prediction_idx = header_fields.index("susceptibility")
+        drug_idx = header_fields.index("drug")
+        species_idx = header_fields.index("species")
+        lineage_idx = header_fields.index("lineage")
+
+        samples = set()
+        for row in fp:
+            fields = [s.strip('"') for s in row.split(",")]
+            sample = fields[sample_idx]
+            samples.add(sample)
+            drug = fields[drug_idx]
+            pred = fields[prediction_idx]
+            report["species"] = fields[species_idx]
+            report["lineage"] = fields[lineage_idx]
+            report[drug] = pred
+
+        if len(samples) > 1:
+            eprint(f"ERROR: Got more than one sample in {path}")
+            sys.exit(1)
+
+        report["sample"] = sample
+        print(report)
+        return report
+
+
+def extract_json_data(path: Path) -> Dict[str, str]:
+    report = dict()
+    with open(path) as fp:
+        data = json.load(fp)
+
+    samples = list(data.keys())
+    if len(samples) > 1:
+        eprint(f"ERROR: Got moe than one sample in {path}")
+        sys.exit(1)
+
+    report["sample"] = samples[0]
+
+    for drug, info in data[samples[0]]["susceptibility"].items():
+        pred = info["predict"]
+        report[drug] = pred
+
+    phylo = data[samples[0]].get("phylogenetics", {})
+    report["species"] = ";".join(list(phylo.get("species", {}).keys()))
+    lineages = [
+        s.replace("lineage", "") for s in phylo.get("lineage", {}).get("lineage", {})
+    ]
+    report["lineage"] = ";".join(lineages)
+
+    return report
+
+
+def extract_data(path: Path) -> Dict[str, str]:
+    if path.suffix == ".csv":
+        return extract_csv_data(path)
+    elif path.suffix == ".json":
+        return extract_json_data(path)
+    else:
+        eprint(f"ERROR: {path} is an unknown file type")
+        sys.exit(1)
+
+
+def eprint(msg: str):
+    print(msg, file=sys.stderr)
+
+
+def main():
+    if sys.version_info < (3, 6, 0):
+        eprint("You need python 3.6 or later to run this script")
+        sys.exit(1)
+
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+
+    parser.add_argument(
+        "src",
+        type=Path,
+        metavar="DIR/FILES",
+        nargs="+",
+        help="A directory containing mykrobe reports, or a list of mykrobe report files",
+    )
+    parser.add_argument(
+        "-d",
+        "--delim",
+        help="Delimiting character to use in the output file [default: %(default)s]",
+        default=",",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="File path to save output to [default: stdout]",
+        type=Path,
+    )
+
+    args = parser.parse_args()
+
+    delim = args.delim
+    input_files = []
+    for p in args.src:
+        if p.is_dir():
+            input_files.append(list(p.glob("*.csv")))
+            input_files.append(list(p.glob("*.json")))
+        else:
+            input_files.append(p)
+
+    eprint(f"Found {len(input_files)} mykrobe reports")
+
+    drugs = set()
+    reports = dict()
+    for p in input_files:
+        data = extract_data(p)
+        reports[p] = data
+        for k in data:
+            if k in ("sample", "species", "lineage"):
+                continue
+            drugs.add(k)
+
+    fp_out = args.output.open("w") if args.output is not None else sys.stdout
+    print(delim.join(["sample", "species", "lineage", *sorted(drugs)]), file=fp_out)
+
+    for p, data in reports.items():
+        row = []
+        for k in ["sample", "species", "lineage"]:
+            row.append(data[k])
+
+        for drug in sorted(drugs):
+            row.append(data.get(drug, ""))
+
+        print(delim.join(row), file=fp_out)
+
+    fp_out.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -132,6 +132,7 @@ setup(
         "mongoengine",
         "requests",
         "numpy",
+        "intervaltree~=3.1"
     ],
     entry_points={
         "console_scripts": [

--- a/src/mykrobe/cmds/amr.py
+++ b/src/mykrobe/cmds/amr.py
@@ -293,7 +293,7 @@ def run(parser, args):
     cp.run()
     logger.debug("CoverageParser complete")
 
-    if ref_data["species_phylo_group"] is None:
+    if ref_data["species_phylo_group"] is None or args.targeted:
         phylogenetics = {}
         depths = [cp.estimate_depth()]
     else:

--- a/src/mykrobe/cmds/amr.py
+++ b/src/mykrobe/cmds/amr.py
@@ -156,6 +156,7 @@ def ref_data_from_args(args):
             "kmer": args.kmer,
             "version": "custom",
             "species_phylo_group": None,
+            "panel_name": "custom",
         }
     else:
         data_dir = DataDir(args.panels_dir)
@@ -170,6 +171,7 @@ def ref_data_from_args(args):
             "kmer": species_dir.kmer(),
             "version": species_dir.version(),
             "species_phylo_group": species_dir.species_phylo_group(),
+            "panel_name": species_dir.panel_name,
         }
 
     if ref_data["lineage_json"] is None:
@@ -259,11 +261,13 @@ def run(parser, args):
         and ref_data["lineage_json"] is None
     ):
         logger.info(
-            "Forcing --report_all_calls because species is 'custom' and options --custom_variant_to_resistance_json,--custom_lineage_json were not used"
+            "Forcing --report_all_calls because species is 'custom' and options "
+            "--custom_variant_to_resistance_json,--custom_lineage_json were not used"
         )
         args.report_all_calls = True
     logger.info(
-        f"Running mykrobe predict using species {args.species}, and panel version {ref_data['version']}"
+        f"Running mykrobe predict using species {args.species}, panel version "
+        f"{ref_data['version']}, and panel {ref_data['panel_name']}"
     )
 
     if args.tmp is None:
@@ -272,10 +276,11 @@ def run(parser, args):
     if args.ont:
         args.expected_error_rate = ONT_E_RATE
         logger.info(
-            f"Set expected error rate to {args.expected_error_rate} because --ont flag was used"
+            f"Set expected error rate to {args.expected_error_rate} because --ont flag "
+            f"was used"
         )
         args.ploidy = ONT_PLOIDY
-        logger.info(f"Set ploidy to {args.ploidy} because --ont flag used")
+        logger.info(f"Set ploidy to {args.ploidy} because --ont flag was used")
 
     # Run Cortex
     cp = CoverageParser(

--- a/src/mykrobe/cmds/amr.py
+++ b/src/mykrobe/cmds/amr.py
@@ -295,6 +295,7 @@ def run(parser, args):
         tmp_dir=args.tmp,
         skeleton_dir=args.skeleton_dir,
         memory=args.memory,
+        targeted=args.targeted,
     )
     cp.run()
     logger.debug("CoverageParser complete")

--- a/src/mykrobe/parser.py
+++ b/src/mykrobe/parser.py
@@ -202,6 +202,12 @@ parser_amr.add_argument(
     action="store_true",
     help=f"Sample is from targeted sequencing - not WGS",
 )
+parser_amr.add_argument(
+    "-z",
+    "--compress",
+    action="store_true",
+    help="Compress JSON output with gzip",
+)
 parser_amr.set_defaults(func=run_subtool)
 
 

--- a/src/mykrobe/parser.py
+++ b/src/mykrobe/parser.py
@@ -199,8 +199,8 @@ parser_amr.add_argument(
 parser_amr.add_argument(
     "-T",
     "--targeted",
-    action="store_true",
-    help=f"Sample is from targeted sequencing - not WGS",
+    help=f"BED file of regions that sequencing targeted",
+    type=str,
 )
 parser_amr.add_argument(
     "-z",

--- a/src/mykrobe/parser.py
+++ b/src/mykrobe/parser.py
@@ -196,6 +196,12 @@ parser_amr.add_argument(
     choices=["json", "csv", "json_and_csv"],
     default="csv",
 )
+parser_amr.add_argument(
+    "-T",
+    "--targeted",
+    action="store_true",
+    help=f"Sample is from targeted sequencing - not WGS",
+)
 parser_amr.set_defaults(func=run_subtool)
 
 

--- a/src/mykrobe/species_data/species_dir.py
+++ b/src/mykrobe/species_data/species_dir.py
@@ -14,6 +14,7 @@ class SpeciesDir:
         if not os.path.exists(self.manifest_json):
             raise FileNotFoundError(f"Manifest file not found in species directory {self.root_dir}. Expected to find {self.manifest_json}.")
         self.panel = None
+        self.panel_name = None
         self.manifest = load_json(self.manifest_json)
         self.set_panel(self.default_panel())
 

--- a/src/mykrobe/typing/typer/genotyper.py
+++ b/src/mykrobe/typing/typer/genotyper.py
@@ -97,7 +97,10 @@ class CoverageParser(object):
 
     def estimate_depth(self):
         depth = []
-        for variant_covg in self.variant_covgs.values():
+
+        for variant_name, variant_covg in self.variant_covgs.items():
+            if not self._allele_is_in_target_region(variant_name):
+                continue
             if variant_covg.reference_coverage.median_depth > 0:
                 depth.append(variant_covg.reference_coverage.median_depth)
         if not self.targeted:
@@ -145,9 +148,6 @@ class CoverageParser(object):
                     klen,
                 ) = self._parse_summary_covgs_row(row)
                 allele_name = allele.split("?")[0]
-
-                if not self._allele_is_in_target_region(allele):
-                    continue
 
                 if self._is_variant_panel(allele_name):
                     self._parse_variant_panel(row)


### PR DESCRIPTION
This PR will (eventually/hopefully) close #28

### Added

- option to compress JSON output (`-z`/`--compress`)
- specific support for targeted sequencing (`-T`/`--targeted`). Takes a BED file of the regions targeted to aid in the read depth estimation [[#28][28]]
- The script `scripts/combine.py` to combine mykrobe reports into a single CSV file

The major feature addition in this PR is the targeted option. It takes a BED file of the regions the user has amplified and only calculates the expected depth from variants that fall within these regions.

### Motivation

So this implementation has been motivated by some Nanopore targeted sequencing data I have been working with lately. There are two amplification strategies used: PCR and [RPA](https://en.wikipedia.org/wiki/Recombinase_polymerase_amplification). In particular, RPA cannot amplify an entire gene, so regions of genes that have the most variants in a WHO catalogue were chosen. One consequence of this when running vanilla mykrobe is that there are lots of variant with median depth 0/1, which end up drowing out the median depth calculate. To make matters more interesting, some of these samples were sequenced for up to 3 days, so the read depth is crazy high (~100k for some genes).

For example, here is a histogram of variant median depths for one sample (subsampled to theoretical coverage 10,000x)

![image](https://user-images.githubusercontent.com/20403931/194476679-28938290-02ca-4f2a-b757-5399937d47ba.png)

The median depth (expected depth) from mykrobe is 1,074. Using this targeted approach, we get the following histogram

![image](https://user-images.githubusercontent.com/20403931/194478003-82fa7924-3cf7-4b69-915e-ace88ca83a56.png)

The median depth (expected depth) from mykrobe is 4,208. Using this targeted approach, we get the following histogram.

In addition to this, comparing DST predictions, before this option, I was finding lots of poor quality indels being called (e.g. #139; see our discussion in the slack channel too). After this change, I didn't see any of those.

One last thing to consider is whether we need to change the min. proportion expected depth. This is potentially just because of our high depth, but I have come across a case where we filter out a good call because it only has 14% of the expected depth. This isn't crazy low in the context of targeted sequencing where it is possible different genes amplify differently. I'm also not sure whether it is normal for targeted sequencing to produce much higher depths than WGS (I suspect it does) and so lowering the default from 0.3 to something like 0.1 might not be insane? Thoughts?