### PR TITLE
Fix windows build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -106,8 +106,8 @@ jobs:
     - name: Install dependencies
       run: |
         git clone --recursive -b geno_kmer_count https://github.com/phelimb/mccortex mccortex
-        cd mccortex 
-        make MAXK=31 
+        cd mccortex
+        make MAXK=31
         cd ..
         cp mccortex/bin/mccortex31 src/mykrobe/cortex/
         python -m pip install -r requirements.txt wheel pyinstaller
@@ -174,6 +174,8 @@ jobs:
       env:
         OUTPUT_TARBALL: mykrobe.command_line.windows.${{env.RELEASE_VERSION}}.tar.gz
       run: |
+        Set-Service mongodb -StartupType Automatic
+        Start-Service -Name mongodb
         export PYTHONPATH="/mingw64/lib/python3.10/:/mingw64/lib/python3.10/site-packages:${PYTHONPATH}"
         C:\\msys64\\mingw64\\bin\\python3.exe -m pip install pyinstaller requests pytest
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -174,8 +174,7 @@ jobs:
       env:
         OUTPUT_TARBALL: mykrobe.command_line.windows.${{env.RELEASE_VERSION}}.tar.gz
       run: |
-        Set-Service mongodb -StartupType Automatic
-        Start-Service -Name mongodb
+        mongod &
         export PYTHONPATH="/mingw64/lib/python3.10/:/mingw64/lib/python3.10/site-packages:${PYTHONPATH}"
         C:\\msys64\\mingw64\\bin\\python3.exe -m pip install pyinstaller requests pytest
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -170,11 +170,15 @@ jobs:
       run: echo "RELEASE_VERSION=test" >> $GITHUB_ENV
       shell: msys2 {0}
 
+    - name: Start MongoDB service
+      run: |
+        sc.exe config MongoDB start= auto
+        sc.exe start MongoDB
+
     - name: Test and build command line tarball
       env:
         OUTPUT_TARBALL: mykrobe.command_line.windows.${{env.RELEASE_VERSION}}.tar.gz
       run: |
-        mongod &
         export PYTHONPATH="/mingw64/lib/python3.10/:/mingw64/lib/python3.10/site-packages:${PYTHONPATH}"
         C:\\msys64\\mingw64\\bin\\python3.exe -m pip install pyinstaller requests pytest
 

--- a/ci/windows_file_fixes.py
+++ b/ci/windows_file_fixes.py
@@ -14,6 +14,16 @@ def fix_file(filename, to_replace):
         print(*lines, sep="", file=f)
 
 
+def fix_file_sed_style(filename, to_replace, replace_with):
+    lines = []
+    print("Replacing all", to_replace, "with", replace_with, "in file", filename)
+    with open(filename) as f:
+        for line in f:
+            lines.append(line.replace(to_replace, replace_with))
+
+    with open(filename, "w") as f:
+        print(*lines, sep="", file=f)
+
 filename = os.path.join("mccortex", "src", "global", "util.h")
 to_replace = {
     "const uint8_t rev_nibble_table[16];\n": "extern const uint8_t rev_nibble_table[16];\n"
@@ -77,3 +87,10 @@ to_replace = {
        "LIBS=-lz -lm -lpthread\n": "LIBS=-lpthread -lz -lm -lws2_32 -lz -llzma -lcurl -lbz2\n",
 }
 fix_file(filename, to_replace)
+
+
+bwa_files = ["bwtgap.c", "bwtgap.h", "bwtindex.c", "bwt_lite.c"]
+bwa_dir = os.path.join("mccortex", "libs", "bwa")
+for filename in bwa_files:
+    fix_file_sed_style(os.path.join(bwa_dir, filename), "u_int32_t", "uint32_t")
+


### PR DESCRIPTION
Fix #172 

We are getting bwa compile errors on windows like this:

```
    error: unknown type name ‘u_int32_t`
```

BWA uses this a few times, but is mostly `uint32_t`. Replace them all with `uint32_t`.