### PR TITLE
Report species probe info

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -179,7 +179,7 @@ jobs:
       env:
         OUTPUT_TARBALL: mykrobe.command_line.windows.${{env.RELEASE_VERSION}}.tar.gz
       run: |
-        export PYTHONPATH="/mingw64/lib/python3.10/:/mingw64/lib/python3.10/site-packages:${PYTHONPATH}"
+        export PYTHONPATH="/mingw64/lib/python3.11/:/mingw64/lib/python3.11/site-packages:${PYTHONPATH}"
         C:\\msys64\\mingw64\\bin\\python3.exe -m ensurepip --upgrade
         C:\\msys64\\mingw64\\bin\\python3.exe -m pip install pyinstaller requests pytest
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -180,6 +180,7 @@ jobs:
         OUTPUT_TARBALL: mykrobe.command_line.windows.${{env.RELEASE_VERSION}}.tar.gz
       run: |
         export PYTHONPATH="/mingw64/lib/python3.10/:/mingw64/lib/python3.10/site-packages:${PYTHONPATH}"
+        C:\\msys64\\mingw64\\bin\\python3.exe -m ensurepip --upgrade
         C:\\msys64\\mingw64\\bin\\python3.exe -m pip install pyinstaller requests pytest
 
         echo "clone mccortex"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
-- When using `--debug` flag, log probe coverage/depth info and also each
+- When using `--debug` flag, log species probe coverage/depth info and also each
   time a probe is rejected due to low coverage and/or depth.
 
 ## [0.12.2]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- When using `--debug` flag, log probe coverage/depth info and also each
+  time a probe is rejected due to low coverage and/or depth.
+
 ## [0.12.2]
 
 ### Fixed

--- a/src/mykrobe/metagenomics/phylo.py
+++ b/src/mykrobe/metagenomics/phylo.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import json
+import logging
 import os
 import operator
 from mykrobe.utils import median
@@ -8,6 +9,7 @@ from mykrobe.utils import flatten
 from mykrobe.metagenomics.models import MykrobePredictorPhylogeneticsResult
 from mykrobe.stats import percent_coverage_from_expected_coverage
 
+logger = logging.getLogger(__name__)
 
 DEFAULT_THRESHOLD = 30
 
@@ -141,8 +143,10 @@ class SpeciesPredictor(object):
             _median = covg_dict.get("median", [0])
             minimum_percentage_coverage_required = percent_coverage_from_expected_coverage(
                 self.expected_depth) * self.threshold.get(phylo_group, DEFAULT_THRESHOLD)
+            logger.debug(f"Probe coverage. probe={phylo_group} percent_covered={total_percent_covered} median_cov={median(_median)}")
             if total_percent_covered < minimum_percentage_coverage_required or median(
                     _median) < 0.1 * self.expected_depth:
+                logger.debug(f"Probe rejected. probe={phylo_group}, total percent covered={total_percent_covered} < {minimum_percentage_coverage_required}=min required, or median depth={median(_median)} < {round(0.1 * self.expected_depth, 1)} = 10% of expected depth of {self.expected_depth}")
                 # Remove low coverage nodes
                 _index = [
                     i for i,


### PR DESCRIPTION
Tiny change: when using the `--debug` flag, logs species probe coverage/depth info and which species probes get rejected