### PR TITLE
Always use Mykrobe-tools/mccortex

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -105,7 +105,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        git clone --recursive -b geno_kmer_count https://github.com/phelimb/mccortex mccortex
+        git clone -b v0.0.5 --recursive https://github.com/Mykrobe-tools/mccortex mccortex
         cd mccortex
         make MAXK=31
         cd ..
@@ -185,7 +185,7 @@ jobs:
 
         echo "clone mccortex"
         rm -rf mccortex
-        git clone --recursive -b geno_kmer_count https://github.com/phelimb/mccortex
+        git clone -b v0.0.5 --recursive https://github.com/Mykrobe-tools/mccortex mccortex
         cd mccortex/libs/htslib
         git checkout bcf9bff178f81c9c1cf3a052aeb6cbe32fe5fdcc
         cd ../bcftools

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ COPY . "/${PROJECT}"
 # install mccortex
 WORKDIR "/tmp"
 
-RUN git clone --recursive -b geno_kmer_count https://github.com/phelimb/mccortex \
+RUN git clone -b v0.0.5 --recursive https://github.com/Mykrobe-tools/mccortex mccortex \
     && cd mccortex \
     && make MAXK=31 \
     && cp bin/mccortex31 /${PROJECT}/src/mykrobe/cortex/ \

--- a/ci/install_mykrobe_linux.sh
+++ b/ci/install_mykrobe_linux.sh
@@ -23,7 +23,7 @@ python -m pip install -U pip
 
 cd $MYKROBE_ROOT_DIR
 rm -rf mccortex
-git clone --recursive -b geno_kmer_count https://github.com/Mykrobe-tools/mccortex mccortex
+git clone -b v0.0.5 --recursive https://github.com/Mykrobe-tools/mccortex mccortex
 cd mccortex
 make
 cd ..


### PR DESCRIPTION
Always get mccortex from MYkrobe-tools/mccortex. Was previsouly not consistent across linux/docker/github actions.

Specify using mccortex tag v.0.0.5.