### PR TITLE
Release v0.13.0 prep

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -148,6 +148,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   windows_build:
+    if: false  # disable for now because is broken
     name: Build Windows command line
     runs-on: windows-2019
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   reads, then push that call up to the parent node. Code still works as normal
   on the existing (soon to be old) panels.
 
+- When reporting panel version in JSON file and stderr logging, only had
+  the "main" version of the collection of panels, eg "20220705" for tb.
+  Changed to also report the specific panel used, eg "20220705/202206".
 
 ## [0.12.2]
 

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ def read(*names, **kwargs):
 
 setup(
     name="mykrobe",
-    version="0.12.2",
+    version="0.13.0",
     license="MIT",
     description="Antibiotic resistance prediction in minutes",
     author="Phelim Bradley",

--- a/src/mykrobe/cmds/amr.py
+++ b/src/mykrobe/cmds/amr.py
@@ -169,7 +169,7 @@ def ref_data_from_args(args):
             "lineage_json": species_dir.json_file("lineage"),
             "ncbi_names_json": species_dir.json_file("ncbi_names"),
             "kmer": species_dir.kmer(),
-            "version": species_dir.version(),
+            "version": species_dir.version() + "/" + species_dir.panel_name,
             "species_phylo_group": species_dir.species_phylo_group(),
         }
 


### PR DESCRIPTION
Small changes to be ready for release 0.13.0:

* Report the full panel version. Was previously only saying the "main" version of the panel collection (ie figshare tarball version). Added in the actual panel version, e.g. previsouly it would say 20220705 for all tb panels, but now says eg 20220705/202206 if the panel version 202206 was used.
* Windows build disabled because it's currently broken. We won't include windows in 0.13.0
* version changed to 0.13.0